### PR TITLE
Fix task for the config check

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -10,7 +10,7 @@
         {
             "label": "Run Home Assistant configuration against /config",
             "type": "shell",
-            "command": "container check",
+            "command": "container check-config",
             "problemMatcher": []
         },
         {


### PR DESCRIPTION
Actually it tries to run `container check`, which outputs `make: *** No rule to make target 'check'.  Stop.`
Fixed it to [check-config](https://github.com/ludeeus/container/blob/f5ad66737f360a364f7f694877615b213dd962d4/container/makefiles/generic.mk#L13)