### PR TITLE
Update Github Release yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,22 +10,59 @@ jobs:
     name: "Release"
     runs-on: "ubuntu-latest"
     steps:
-      - name: "Checkout the repository"
-        uses: "actions/checkout@v3.5.0"
+      - name: "⬇️ Checkout the repository"
+        uses: actions/checkout@v3
 
-      - name: "Adjust version number"
-        shell: "bash"
+      - name: 🔢 Get release version
+        id: version
+        uses: home-assistant/actions/helpers/version@master
+
+      - name: ℹ️ Get integration information
+        id: information
         run: |
-          yq -i -o json '.version="${{ github.event.release.tag_name }}"' \
-            "${{ github.workspace }}/custom_components/integration_blueprint/manifest.json"
-
-      - name: "ZIP the integration directory"
-        shell: "bash"
+          name=$(find custom_components/ -type d -maxdepth 1 | tail -n 1 | cut -d "/" -f2)
+          echo "::set-output name=name::$name"
+          min_ha_version=$(jq -r '.homeassistant' ${{ github.workspace }}/hacs.json)
+          echo "::set-output name=min_ha_version::$min_ha_version"
+      - name: 🖊️ Set version number
         run: |
-          cd "${{ github.workspace }}/custom_components/integration_blueprint"
-          zip integration_blueprint.zip -r ./
-
-      - name: "Upload the ZIP file to the release"
-        uses: softprops/action-gh-release@v0.1.15
+          sed -i '/INTEGRATION_VERSION = /c\INTEGRATION_VERSION = "${{ steps.version.outputs.version }}"' \
+            "${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/const.py"
+          jq '.version = "${{ steps.version.outputs.version }}"' \
+            "${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/manifest.json" > tmp \
+            && mv -f tmp "${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/manifest.json"
+      - name: 🖊️ Set min required HA version
+        run: |
+          sed -i '/MIN_REQUIRED_HA_VERSION = /c\MIN_REQUIRED_HA_VERSION = "${{ steps.information.outputs.min_ha_version }}"' \
+            "${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/const.py"
+      - name: 👀 Validate data
+        run: |
+          if ! grep -q 'INTEGRATION_VERSION = "${{ steps.version.outputs.version }}"' ${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/const.py; then
+            echo "The version in custom_components/${{ steps.information.outputs.name }}/const.py was not correct"
+            cat ${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/const.py | grep INTEGRATION_VERSION
+            exit 1
+          fi
+          manifestversion=$(jq -r '.version' ${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/manifest.json)
+          if [ "$manifestversion" != "${{ steps.version.outputs.version }}" ]; then
+            echo "The version in custom_components/${{ steps.information.outputs.name }}/manifest.json was not correct"
+            echo "$manifestversion"
+            exit 1
+          fi
+          if ! grep -q 'MIN_REQUIRED_HA_VERSION = "${{ steps.information.outputs.min_ha_version }}"' ${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/const.py; then
+            echo "The MIN_REQUIRED_HA_VERSION in custom_components/${{ steps.information.outputs.name }}/const.py was not correct"
+            cat ${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/const.py | grep MIN_REQUIRED_HA_VERSION
+            exit 1
+          fi
+      - name: 📦 Create zip file for the integration
+        run: |
+          cd "${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}"
+          zip ${{ steps.information.outputs.name }}.zip -r ./
+      - name: 📤 Upload the zip file as a release asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: ${{ github.workspace }}/custom_components/integration_blueprint/integration_blueprint.zip
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: "${{ github.workspace }}/custom_components/${{ steps.information.outputs.name }}/${{ steps.information.outputs.name }}.zip"
+          asset_name: ${{ steps.information.outputs.name }}.zip
+          asset_content_type: application/zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,7 @@
 name: "Release"
 
+permissions: write-all
+
 on:
   release:
     types:

--- a/custom_components/integration_blueprint/const.py
+++ b/custom_components/integration_blueprint/const.py
@@ -1,9 +1,14 @@
 """Constants for integration_blueprint."""
 from logging import Logger, getLogger
 
+################################
+# Do not change! Will be set by release workflow
+INTEGRATION_VERSION = "main"  # git tag will be used
+MIN_REQUIRED_HA_VERSION = "0.0.0"  # set min required version in hacs.json
+################################
+
 LOGGER: Logger = getLogger(__package__)
 
 NAME = "Integration blueprint"
 DOMAIN = "integration_blueprint"
-VERSION = "0.0.0"
 ATTRIBUTION = "Data provided by http://jsonplaceholder.typicode.com/"

--- a/custom_components/integration_blueprint/entity.py
+++ b/custom_components/integration_blueprint/entity.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import ATTRIBUTION, DOMAIN, NAME, VERSION
+from .const import ATTRIBUTION, DOMAIN, NAME, INTEGRATION_VERSION
 from .coordinator import BlueprintDataUpdateCoordinator
 
 
@@ -20,6 +20,6 @@ class IntegrationBlueprintEntity(CoordinatorEntity):
         self._attr_device_info = DeviceInfo(
             identifiers={(DOMAIN, self.unique_id)},
             name=NAME,
-            model=VERSION,
+            model=INTEGRATION_VERSION,
             manufacturer=NAME,
         )

--- a/hacs.json
+++ b/hacs.json
@@ -2,7 +2,7 @@
     "name": "Integration blueprint",
     "filename": "integration_blueprint.zip",
     "hide_default_branch": true,
-    "homeassistant": "2022.2.0",
+    "homeassistant": "2023.3.0",
     "render_readme": true,
     "zip_release": true
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 colorlog==6.7.0
-homeassistant==2022.2.0
-pip>=8.0.3,<20.3
+homeassistant==2023.3.0
+pip>=8.0.3,<23.1
 ruff==0.0.259


### PR DESCRIPTION
When i used this repo as a template, I noticed that the release pipeline didn't work out of the box.

Looking through other codebases, I found a more up to date release pipeline, and added permissions to the yaml as well, so a new user doesn't need to troubleshoot why the release pipeline isn't work.

Also bumped the default home assistant version to 2023.3.0
