### PR TITLE
Replace deprecated devcontainer features

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -37,6 +37,6 @@
     },
     "remoteUser": "vscode",
     "features": {
-        "rust": "latest"
+        "ghcr.io/devcontainers/features/rust:1": {}
     }
 }


### PR DESCRIPTION
While starting the dev container, the following message is displayed:


```
[3285 ms] * Processing feature: rust
[3285 ms] (!) WARNING: Using the deprecated ‘rust’ Feature. See https://github.com/devcontainers/features/tree/main/src/rust#example-usage for the updated Feature.
```