### PR TITLE
Remove Rust from devcontainer

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -35,8 +35,5 @@
             }
         }
     },
-    "remoteUser": "vscode",
-    "features": {
-        "ghcr.io/devcontainers/features/rust:1": {}
-    }
+    "remoteUser": "vscode"
 }


### PR DESCRIPTION
It is not necessary for ruff, which gets installed with pip.

This makes the devcontainer build faster.