### PR TITLE
Remove defaults for entity model, name and manufacturer

### DIFF
--- a/custom_components/integration_blueprint/entity.py
+++ b/custom_components/integration_blueprint/entity.py
@@ -26,6 +26,6 @@ class IntegrationBlueprintEntity(CoordinatorEntity[BlueprintDataUpdateCoordinato
                 ),
             },
             name=coordinator.config_entry.runtime_data.integration.name,
-            model=coordinator.config_entry.runtime_data.integration.version,
+            model=str(coordinator.config_entry.runtime_data.integration.version),
             manufacturer=coordinator.config_entry.runtime_data.integration.name,
         )

--- a/custom_components/integration_blueprint/entity.py
+++ b/custom_components/integration_blueprint/entity.py
@@ -25,7 +25,4 @@ class IntegrationBlueprintEntity(CoordinatorEntity[BlueprintDataUpdateCoordinato
                     coordinator.config_entry.entry_id,
                 ),
             },
-            name=coordinator.config_entry.runtime_data.integration.name,
-            model=str(coordinator.config_entry.runtime_data.integration.version),
-            manufacturer=coordinator.config_entry.runtime_data.integration.name,
         )


### PR DESCRIPTION
Using an AwesomeVersion object for the model leads to errors when Home Assistant adds the device to its registry.