### PR TITLE
Use container mount for custom_components inside /config to avoid PYTHONPATH

### DIFF
--- a/.devcontainer.json
+++ b/.devcontainer.json
@@ -11,6 +11,13 @@
             "onAutoForward": "notify"
         }
     },
+    // Mount the path to custom_components in container path <root>/config
+    // This let's us have the structure we want <root>/custom_components/integration_blueprint
+    // while at the same time have Home Assistant configuration inside <root>/config
+    // without resulting to symlinks.
+    "mounts": [
+        "source=${localWorkspaceFolder}/custom_components,target=${containerWorkspaceFolder}/config/custom_components,type=bind,consistency=cached"
+    ],
     "customizations": {
         "vscode": {
             "extensions": [

--- a/scripts/develop
+++ b/scripts/develop
@@ -10,11 +10,5 @@ if [[ ! -d "${PWD}/config" ]]; then
     hass --config "${PWD}/config" --script ensure_config
 fi
 
-# Set the path to custom_components
-## This let's us have the structure we want <root>/custom_components/integration_blueprint
-## while at the same time have Home Assistant configuration inside <root>/config
-## without resulting to symlinks.
-export PYTHONPATH="${PYTHONPATH}:${PWD}/custom_components"
-
 # Start Home Assistant
 hass --config "${PWD}/config" --debug


### PR DESCRIPTION
Use container [mount](https://containers.dev/implementors/json_reference/) instead of relying on PYTHONPATH for integration to be found by hass.

Allow integration to be found by hass without polluting module search path.

It's quite common (good practice or not) in the wild for integrations and their lib `requirement` to share the same package name. Adding custom_components to PYTHONPATH does not support this scenario. Integrations that are currently based on this template will stop working if brought to sync with this repo. The error thrown is confusing since the requirement is installed by hass but  will resolve to the integration package itself.

fixes #130 