### PR TITLE
Delete removed rule "ANN101" from the Ruff ignore list

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,7 +8,6 @@ select = [
 ]
 
 ignore = [
-    "ANN101", # Missing type annotation for `self` in method
     "ANN401", # Dynamically typed expressions (typing.Any) are disallowed
     "D203", # no-blank-line-before-class (incompatible with formatter)
     "D212", # multi-line-summary-first-line (incompatible with formatter)


### PR DESCRIPTION
The rule has been removed from Ruff and when executing `ruff check` the following message appears:

> warning: The following rules have been removed and ignoring them has no effect:
>    - ANN101