### PR TITLE
Change hacs version number in hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,4 +1,5 @@
 {
     "name": "Integration blueprint",
-    "homeassistant": "2025.2.4"
+    "homeassistant": "2025.2.4",
+    "hacs": "2.0.5"
 }


### PR DESCRIPTION
I propose to ~~remove~~ update the old hacs version number in the hacs.json file. With the old version number in the file, a download of other releases then the "latest" will not work.