### PR TITLE
feat: Add Turkish language support

### DIFF
--- a/custom_components/integration_blueprint/translations/tr.json
+++ b/custom_components/integration_blueprint/translations/tr.json
@@ -1,0 +1,21 @@
+{
+    "config": {
+        "step": {
+            "user": {
+                "description": "Yapilandirma konusunda yardima ihtiyaciniz varsa buraya bakin: https://github.com/ludeeus/integration_blueprint",
+                "data": {
+                    "username": "Kullanici Adi",
+                    "password": "Parola"
+                }
+            }
+        },
+        "error": {
+            "auth": "Kullanici adi veya parola hatali.",
+            "connection": "Sunucuya baglanilamiyor.",
+            "unknown": "Bilinmeyen bir hata olustu."
+        },
+        "abort": {
+            "already_configured": "Bu giris zaten yapilandirilmis."
+        }
+    }
+}


### PR DESCRIPTION
Add Turkish (tr.json) translation file for Home Assistant integration blueprint. This enables Turkish-speaking users to use the integration in their native language.

Translations include:
- Configuration flow UI text
- Error messages
- Abort messages